### PR TITLE
Fix exporter unittest occasional error

### DIFF
--- a/exporters/otlp/otlptrace/internal/otlptracetest/client.go
+++ b/exporters/otlp/otlptrace/internal/otlptracetest/client.go
@@ -69,7 +69,7 @@ func testClientStopHonorsTimeout(t *testing.T, client otlptrace.Client) {
 	defer cancel()
 	<-ctx.Done()
 
-	if err := e.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+	if err := e.Shutdown(ctx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected context DeadlineExceeded error, got %v", err)
 	}
 }
@@ -88,7 +88,7 @@ func testClientStopHonorsCancel(t *testing.T, client otlptrace.Client) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := e.Shutdown(ctx); !errors.Is(err, context.Canceled) {
+	if err := e.Shutdown(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context canceled error, got %v", err)
 	}
 }


### PR DESCRIPTION
A few days ago, I open a pr https://github.com/open-telemetry/opentelemetry-go/pull/2987 , try fix golangci-lint not working correctly. But the pr checks occur a error in unittest `TestExporterShutdown/testClientStopHonorsTimeout` for exporter grpc client `Stop()` function :[exporters/otlp/otlptrace/otlptracegrpc/client.go#L130](https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/otlp/otlptrace/otlptracegrpc/client.go#L130)

I figure out in `Stop(ctx context.Context)` the `select` for `<-ctx.Done()` and `acquired ` may reach at the same time. In `select` if `acquired`  be exec first, The `Stop(ctx context.Context)` function  may return nil . when `Stop(ctx context.Context)` function return nil, unittest `TestExporterShutdown/testClientStopHonorsTimeout` and `TestExporterShutdown/testClientStopHonorsTimeout` will failure. 

This is a occasional error. you can recurrent it by this shell. 
```shell
cd exporters/otlp/otlptrace/otlptracegrpc/
while true ; do go clean -testcache | go list \
| xargs go test -v -timeout 60s -race -run \
  TestExporterShutdown/testClientStopHonorsTimeout; sleep 0.5;  done;
```

