### PR TITLE
Update file `semconv/template.j2`, replace `required` by `requirementlevel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: [1.18, 1.17]
+        go-version: [1.19, 1.18, 1.17]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.9.0/0.0.3] - 2022-08-01
+
 ### Added
 
-- Add the `go.opentelemetry.io/otel/semconv/v1.12.0` package.
-  The package contains semantic conventions from the `v1.12.0` version of the OpenTelemetry specification. (#3010)
+- Add support for Schema Files format 1.1.x (metric "split" transform) with the new `go.opentelemetry.io/otel/schema/v1.1` package. (#2999)
 - Add the `go.opentelemetry.io/otel/semconv/v1.11.0` package.
   The package contains semantic conventions from the `v1.11.0` version of the OpenTelemetry specification. (#3009)
-- Add http.method attribute to http server metric. (#3018)
+- Add the `go.opentelemetry.io/otel/semconv/v1.12.0` package.
+  The package contains semantic conventions from the `v1.12.0` version of the OpenTelemetry specification. (#3010)
+- Add the `http.method` attribute to HTTP server metric from all `go.opentelemetry.io/otel/semconv/*` packages. (#3018)
 
 ### Fixed
 
-- Invalid warning for context setup being deferred in OpenTracing bridge (#3029).
+- Invalid warning for context setup being deferred in `go.opentelemetry.io/otel/bridge/opentracing` package. (#3029)
 
 ## [1.8.0/0.31.0] - 2022-07-08
 
@@ -26,7 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add support for `opentracing.TextMap` format in the `Inject` and `Extract` methods
 of the `"go.opentelemetry.io/otel/bridge/opentracing".BridgeTracer` type. (#2911)
-- Add support for Schema Files format 1.1.x (metric "split" transform). (#2999)
 
 ### Changed
 
@@ -1889,7 +1891,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.9.0...HEAD
+[1.9.0/0.0.3]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.9.0
 [1.8.0/0.31.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.8.0
 [1.7.0/0.30.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.7.0
 [0.29.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metric/v0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Support Go 1.19.
+  Include compatibility testing and document support. (#3077)
+
 ## [1.9.0/0.0.3] - 2022-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support Go 1.19.
   Include compatibility testing and document support. (#3077)
 
+### Fixed
+
+- Fix misidentification of OpenTelemetry `SpanKind` in OpenTracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`).  (#3096)
+
 ## [1.9.0/0.0.3] - 2022-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,14 +41,19 @@ This project is tested on the following systems.
 
 | OS      | Go Version | Architecture |
 | ------- | ---------- | ------------ |
+| Ubuntu  | 1.19       | amd64        |
 | Ubuntu  | 1.18       | amd64        |
 | Ubuntu  | 1.17       | amd64        |
+| Ubuntu  | 1.19       | 386          |
 | Ubuntu  | 1.18       | 386          |
 | Ubuntu  | 1.17       | 386          |
+| MacOS   | 1.19       | amd64        |
 | MacOS   | 1.18       | amd64        |
 | MacOS   | 1.17       | amd64        |
+| Windows | 1.19       | amd64        |
 | Windows | 1.18       | amd64        |
 | Windows | 1.17       | amd64        |
+| Windows | 1.19       | 386          |
 | Windows | 1.18       | 386          |
 | Windows | 1.17       | 386          |
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,23 @@ Project versioning information and stability guarantees can be found in the
 
 ### Compatibility
 
-OpenTelemetry-Go attempts to track the current supported versions of the
-[Go language](https://golang.org/doc/devel/release#policy). The release
-schedule after a new minor version of go is as follows:
+OpenTelemetry-Go ensures compatibility with the current supported versions of
+the [Go language](https://golang.org/doc/devel/release#policy):
 
-- The first release or one month, which ever is sooner, will add build steps for the new go version.
-- The first release after three months will remove support for the oldest go version.
+> Each major Go release is supported until there are two newer major releases.
+> For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release.
 
-This project is tested on the following systems.
+For versions of Go that are no longer supported upstream, opentelemetry-go will
+stop ensuring compatibility with these versions in the following manner:
+
+- A minor release of opentelemetry-go will be made to add support for the new
+  supported release of Go.
+- The following minor release of opentelemetry-go will remove compatibility
+  testing for the oldest (now archived upstream) version of Go. This, and
+  future, releases of opentelemetry-go may include features only supported by
+  the currently supported versions of Go.
+
+Currently, this project supports the following environments.
 
 | OS      | Go Version | Architecture |
 | ------- | ---------- | ------------ |

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,10 +4,10 @@ go 1.17
 
 require (
 	go.opencensus.io v0.23.0
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -502,17 +502,19 @@ func otTagsToOTelAttributesKindAndError(tags map[string]interface{}) ([]attribut
 	for k, v := range tags {
 		switch k {
 		case string(otext.SpanKind):
+			sk := v
 			if s, ok := v.(string); ok {
-				switch strings.ToLower(s) {
-				case "client":
-					kind = trace.SpanKindClient
-				case "server":
-					kind = trace.SpanKindServer
-				case "producer":
-					kind = trace.SpanKindProducer
-				case "consumer":
-					kind = trace.SpanKindConsumer
-				}
+				sk = otext.SpanKindEnum(strings.ToLower(s))
+			}
+			switch sk {
+			case otext.SpanKindRPCClientEnum:
+				kind = trace.SpanKindClient
+			case otext.SpanKindRPCServerEnum:
+				kind = trace.SpanKindServer
+			case otext.SpanKindProducerEnum:
+				kind = trace.SpanKindProducer
+			case otext.SpanKindConsumerEnum:
+				kind = trace.SpanKindConsumer
 			}
 		case string(otext.Error):
 			if b, ok := v.(bool); ok && b {

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -22,9 +22,11 @@ import (
 	"testing"
 
 	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -422,6 +424,47 @@ func TestBridgeTracer_StartSpan(t *testing.T) {
 			assert.NotNil(t, span)
 
 			assert.Equal(t, tc.expectWarnings, warningMessages)
+		})
+	}
+}
+
+func Test_otTagsToOTelAttributesKindAndError(t *testing.T) {
+	tracer := internal.NewMockTracer()
+	sc := &bridgeSpanContext{}
+
+	testCases := []struct {
+		name     string
+		opt      []ot.StartSpanOption
+		expected trace.SpanKind
+	}{
+		{
+			name:     "client",
+			opt:      []ot.StartSpanOption{ext.SpanKindRPCClient},
+			expected: trace.SpanKindClient,
+		},
+		{
+			name:     "server",
+			opt:      []ot.StartSpanOption{ext.RPCServerOption(sc)},
+			expected: trace.SpanKindServer,
+		},
+		{
+			name:     "client string",
+			opt:      []ot.StartSpanOption{ot.Tag{Key: "span.kind", Value: "client"}},
+			expected: trace.SpanKindClient,
+		},
+		{
+			name:     "server string",
+			opt:      []ot.StartSpanOption{ot.Tag{Key: "span.kind", Value: "server"}},
+			expected: trace.SpanKindServer,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _ := NewTracerPair(tracer)
+
+			s := b.StartSpan(tc.name, tc.opt...)
+			assert.Equal(t, s.(*bridgeSpan).otelSpan.(*internal.MockSpan).SpanKind, tc.expected)
 		})
 	}
 }

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -7,8 +7,8 @@ replace go.opentelemetry.io/otel => ../..
 require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.7.2
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/fib
 go 1.17
 
 require (
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/jaeger v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/jaeger v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 )
 
 require (
@@ -19,7 +19,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 )
 

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,11 +10,11 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.31.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.31.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 )
 

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 	google.golang.org/grpc v1.46.2
 )
 
@@ -21,8 +21,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.18.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.17
 
 require (
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.31.0
 	go.opentelemetry.io/otel/metric v0.31.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
@@ -26,8 +26,8 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	go.opentelemetry.io/otel/sdk v1.8.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.9.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/zipkin v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/zipkin v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -5,9 +5,9 @@ go 1.17
 require (
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/header_transport.go
+++ b/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/header_transport.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // Size in bytes for 32-bit ints.
@@ -374,7 +373,7 @@ func (t *THeaderTransport) ReadFrame(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	t.frameReader = ioutil.NopCloser(&t.frameBuffer)
+	t.frameReader = io.NopCloser(&t.frameBuffer)
 
 	// Peek and handle the next 32 bits.
 	buf = t.frameBuffer.Bytes()[:size32]

--- a/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/http_client.go
+++ b/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/http_client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -138,7 +137,7 @@ func (p *THttpClient) closeResponse() error {
 		// reused. Errors are being ignored here because if the connection is invalid
 		// and this fails for some reason, the Close() method will do any remaining
 		// cleanup.
-		io.Copy(ioutil.Discard, p.response.Body)
+		io.Copy(io.Discard, p.response.Body)
 
 		err = p.response.Body.Close()
 	}

--- a/exporters/jaeger/uploader.go
+++ b/exporters/jaeger/uploader.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -308,7 +307,7 @@ func (c *collectorUploader) upload(ctx context.Context, batch *gen.Batch) error 
 		return err
 	}
 
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	if err = resp.Body.Close(); err != nil {
 		return err
 	}

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -5,10 +5,10 @@ go 1.17
 require (
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	google.golang.org/grpc v1.46.2
@@ -23,7 +23,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
@@ -16,7 +16,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -29,7 +28,7 @@ import (
 // DefaultEnvOptionsReader is the default environments reader.
 var DefaultEnvOptionsReader = envconfig.EnvOptionsReader{
 	GetEnv:    os.Getenv,
-	ReadFile:  ioutil.ReadFile,
+	ReadFile:  os.ReadFile,
 	Namespace: "OTEL_EXPORTER_OTLP",
 }
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/tls.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/tls.go
@@ -18,13 +18,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 )
 
 // ReadTLSConfigFromFile reads a PEM certificate file and creates
 // a tls.Config that will use this certifate to verify a server certificate.
 func ReadTLSConfigFromFile(path string) (*tls.Config, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.31.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
@@ -24,7 +24,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -41,7 +40,7 @@ const contentTypeProto = "application/x-protobuf"
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }
@@ -163,7 +162,7 @@ func (d *client) UploadMetrics(ctx context.Context, protoMetrics *metricpb.Resou
 			rErr = newResponseError(resp.Header)
 
 			// Going to retry, drain the body to reuse the connection.
-			if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 				_ = resp.Body.Close()
 				return err
 			}
@@ -223,7 +222,7 @@ func (d *client) newRequest(body []byte) (request, error) {
 // bodyReader returns a closure returning a new reader for buf.
 func bodyReader(buf []byte) func() io.ReadCloser {
 	return func() io.ReadCloser {
-		return ioutil.NopCloser(bytes.NewReader(buf))
+		return io.NopCloser(bytes.NewReader(buf))
 	}
 }
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	google.golang.org/protobuf v1.28.0
 )
@@ -19,10 +19,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel v1.8.0 // indirect
+	go.opentelemetry.io/otel v1.9.0 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.31.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
@@ -149,7 +148,7 @@ func readRequest(r *http.Request) ([]byte, error) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		return readGzipBody(r.Body)
 	}
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }
 
 func readGzipBody(body io.Reader) ([]byte, error) {

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,10 +5,10 @@ go 1.17
 require (
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0

--- a/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
@@ -16,7 +16,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -29,7 +28,7 @@ import (
 // DefaultEnvOptionsReader is the default environments reader.
 var DefaultEnvOptionsReader = envconfig.EnvOptionsReader{
 	GetEnv:    os.Getenv,
-	ReadFile:  ioutil.ReadFile,
+	ReadFile:  os.ReadFile,
 	Namespace: "OTEL_EXPORTER_OTLP",
 }
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -4,10 +4,10 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	go.uber.org/goleak v1.1.12
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
@@ -23,7 +23,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -41,7 +40,7 @@ const contentTypeProto = "application/x-protobuf"
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }
@@ -165,7 +164,7 @@ func (d *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 			rErr = newResponseError(resp.Header)
 
 			// Going to retry, drain the body to reuse the connection.
-			if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 				_ = resp.Body.Close()
 				return err
 			}
@@ -238,7 +237,7 @@ func (d *client) MarshalLog() interface{} {
 // bodyReader returns a closure returning a new reader for buf.
 func bodyReader(buf []byte) func() io.ReadCloser {
 	return func() io.ReadCloser {
-		return ioutil.NopCloser(bytes.NewReader(buf))
+		return io.NopCloser(bytes.NewReader(buf))
 	}
 }
 

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.9.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 	go.opentelemetry.io/proto/otlp v0.18.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
@@ -168,7 +167,7 @@ func readRequest(r *http.Request) ([]byte, error) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		return readGzipBody(r.Body)
 	}
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }
 
 func readGzipBody(body io.Reader) ([]byte, error) {

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.17
 require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/openzipkin/zipkin-go v0.4.0
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/sdk v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/sdk v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/exporters/zipkin/zipkin.go
+++ b/exporters/zipkin/zipkin.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -144,7 +143,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpa
 	// but it is still being read because according to https://golang.org/pkg/net/http/#Response
 	// > The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive" TCP connections
 	// > if the Body is not read to completion and closed.
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return e.errf("failed to read response body: %v", err)
 	}

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -135,7 +135,7 @@ func startMockZipkinCollector(t *testing.T) *mockZipkinCollector {
 }
 
 func (c *mockZipkinCollector) handler(w http.ResponseWriter, r *http.Request) {
-	jsonBytes, err := ioutil.ReadAll(r.Body)
+	jsonBytes, err := io.ReadAll(r.Body)
 	require.NoError(c.t, err)
 	var models []zkmodel.SpanModel
 	err = json.Unmarshal(jsonBytes, &models)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel/trace v1.9.0
 )
 
 require (

--- a/handler_test.go
+++ b/handler_test.go
@@ -17,7 +17,7 @@ package otel
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -129,9 +129,9 @@ func TestHandlerRace(t *testing.T) {
 }
 
 func BenchmarkErrorHandler(b *testing.B) {
-	primary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
-	secondary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
-	tertiary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
+	primary := &errLogger{l: log.New(io.Discard, "", 0)}
+	secondary := &errLogger{l: log.New(io.Discard, "", 0)}
+	tertiary := &errLogger{l: log.New(io.Discard, "", 0)}
 
 	globalErrorHandler.setDelegate(primary)
 
@@ -167,7 +167,7 @@ func BenchmarkGetDefaultErrorHandler(b *testing.B) {
 }
 
 func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
-	SetErrorHandler(&errLogger{l: log.New(ioutil.Discard, "", 0)})
+	SetErrorHandler(&errLogger{l: log.New(io.Discard, "", 0)})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -180,7 +180,7 @@ func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
 
 func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 	globalErrorHandler.setDelegate(
-		&errLogger{l: log.New(ioutil.Discard, "", 0)},
+		&errLogger{l: log.New(io.Discard, "", 0)},
 	)
 
 	eh := GetErrorHandler()
@@ -197,7 +197,7 @@ func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 
 func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 	eh := GetErrorHandler()
-	SetErrorHandler(&errLogger{l: log.New(ioutil.Discard, "", 0)})
+	SetErrorHandler(&errLogger{l: log.New(io.Discard, "", 0)})
 	err := errors.New("benchmark delegated error handler handle")
 
 	b.ReportAllocs()
@@ -210,7 +210,7 @@ func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 }
 
 func BenchmarkSetErrorHandlerDelegation(b *testing.B) {
-	alt := &errLogger{l: log.New(ioutil.Discard, "", 0)}
+	alt := &errLogger{l: log.New(io.Discard, "", 0)}
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 )
 
 require (
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
-	go.opentelemetry.io/otel/trace v1.8.0
+	go.opentelemetry.io/otel v1.9.0
+	go.opentelemetry.io/otel/trace v1.9.0
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -13,9 +13,9 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/metric v0.31.0
-	go.opentelemetry.io/otel/sdk v1.8.0
+	go.opentelemetry.io/otel/sdk v1.9.0
 )
 
 require (
@@ -23,7 +23,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
+	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/sdk/resource/os_unix_test.go
+++ b/sdk/resource/os_unix_test.go
@@ -19,7 +19,7 @@ package resource_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,8 +67,8 @@ func TestUnameError(t *testing.T) {
 func TestGetFirstAvailableFile(t *testing.T) {
 	tempDir := t.TempDir()
 
-	file1, _ := ioutil.TempFile(tempDir, "candidate_")
-	file2, _ := ioutil.TempFile(tempDir, "candidate_")
+	file1, _ := os.CreateTemp(tempDir, "candidate_")
+	file2, _ := os.CreateTemp(tempDir, "candidate_")
 
 	filename1, filename2 := file1.Name(), file2.Name()
 

--- a/semconv/template.j2
+++ b/semconv/template.j2
@@ -16,12 +16,16 @@ Type: {{ attr.attr_type }}
 {%- else %}
 Type: Enum
 {%- endif %}
-{%- if attr.required == Required.ALWAYS %}
-Required: Always
-{%- elif attr.required == Required.CONDITIONAL %}
-Required: {{ attr.required_msg }}
+{%- if attr.requirement_level == RequirementLevel.REQUIRED %}
+RequirementLevel: Required
+{%- elif attr.requirement_level == RequirementLevel.CONDITIONALLY_REQUIRED %}
+RequirementLevel: ConditionallyRequired
+  {%- if attr.requirement_level_msg != "" %} ({{ attr.requirement_level_msg }}){%- endif %}
+{%- elif attr.requirement_level == RequirementLevel.RECOMMENDED %}
+RequirementLevel: Recommended
+  {%- if attr.requirement_level_msg != "" %} ({{ attr.requirement_level_msg }}){%- endif %}
 {%- else %}
-Required: No
+RequirementLevel: Optional
 {%- endif %}
 {{ attr.stability |  replace("Level.", ": ") | capitalize }}
 {%- if attr.deprecated != None %}

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.8.0
+	go.opentelemetry.io/otel v1.9.0
 )
 
 require (

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-var (
+const (
 	maxListMembers = 32
 
 	listDelimiter = ","
@@ -32,15 +32,17 @@ var (
 	withTenantKeyFormat = `[a-z0-9][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
 	valueFormat         = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
 
-	keyRe    = regexp.MustCompile(`^((` + noTenantKeyFormat + `)|(` + withTenantKeyFormat + `))$`)
-	valueRe  = regexp.MustCompile(`^(` + valueFormat + `)$`)
-	memberRe = regexp.MustCompile(`^\s*((` + noTenantKeyFormat + `)|(` + withTenantKeyFormat + `))=(` + valueFormat + `)\s*$`)
-
 	errInvalidKey    errorConst = "invalid tracestate key"
 	errInvalidValue  errorConst = "invalid tracestate value"
 	errInvalidMember errorConst = "invalid tracestate list-member"
 	errMemberNumber  errorConst = "too many list-members in tracestate"
 	errDuplicate     errorConst = "duplicate list-member in tracestate"
+)
+
+var (
+	keyRe    = regexp.MustCompile(`^((` + noTenantKeyFormat + `)|(` + withTenantKeyFormat + `))$`)
+	valueRe  = regexp.MustCompile(`^(` + valueFormat + `)$`)
+	memberRe = regexp.MustCompile(`^\s*((` + noTenantKeyFormat + `)|(` + withTenantKeyFormat + `))=(` + valueFormat + `)\s*$`)
 )
 
 type member struct {

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.8.0"
+	return "1.9.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.8.0
+    version: v1.9.0
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing
@@ -45,7 +45,7 @@ module-sets:
       - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk/metric
   experimental-schema:
-    version: v0.0.2
+    version: v0.0.3
     modules:
       - go.opentelemetry.io/otel/schema
   bridge:


### PR DESCRIPTION
## what happened
When I exec below cmd for regenerate `semconv/v1.12.0`
```
$ export TAG="v1.12.0"
$ export OTEL_SPEC_REPO="/path/to/opentelemetry-specification/"
$ git -C "$OTEL_SPEC_REPO" checkout "tags/$TAG"
$ make semconv-generate
```
 There will be a `jinja2.exceptions.UndefinedError` error as follow:
```sh 
Traceback (most recent call last):
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/main.py", line 241, in <module>
    main()
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/main.py", line 75, in main
    renderer.render(semconv, args.template, args.output, args.pattern)
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/templating/code.py", line 251, in render
    template.stream(data).dump(output_file)
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1618, in dump
    fp.writelines(iterable)
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1613, in <genexpr>
    iterable = (x.encode(encoding, errors) for x in self)  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1662, in __next__
    return self._next()  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1354, in generate
    yield self.environment.handle_exception()
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "$HOME/cncf/opentelemetry/opentelemetry-go/semconv/template.j2", line 62, in top-level template code
    // {{ godoc(attr) | wordwrap | indent(3) | replace("   ", "\t// ") | replace("// //", "//") }}
  File "/usr/local/lib/python3.9/site-packages/jinja2/runtime.py", line 777, in _invoke
    rv = self._func(*arguments)
  File "$HOME/cncf/opentelemetry/opentelemetry-go/semconv/template.j2", line 19, in template
    {%- if attr.required == Required.ALWAYS %}
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 485, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'Required' is undefined
```
## And why 
This error caused by the update in PR  #https://github.com/open-telemetry/build-tools/pull/92/files , Class `Required` is replaced by  `RequirementLevel `.
More details https://github.com/open-telemetry/build-tools/pull/92/files#diff-f62a4dc611090cd2aee181fcd6522c010708dd98d5cf262c4f06ef61a519a25aL31

## What we should do
As the attribute `required` was totally replaced by `requirementlevel` in https://github.com/open-telemetry/opentelemetry-specification/pull/2594.  we should update our `semconv/template.j2` to adopt it.
